### PR TITLE
tiny Bug

### DIFF
--- a/traveler.cpp
+++ b/traveler.cpp
@@ -117,9 +117,9 @@ void Traveler::deSerializePlaces()
         getline(stream, x);
         paymentMethod = x;
         getline(stream, x);
-        room = (x == "true");
+        room = (x == "1");
         getline(stream, x);
-        reserved = (x == "true");
+        reserved = (x == "1");
         getline(stream, x);
         pricePerDay = stoi(x);
         getline(stream, x);


### PR DESCRIPTION
ofstream saves booleans as 0's and 1's not as true's and false's
just quickmerge and don't look back